### PR TITLE
Aumentar rapidez al obtener los linsk de descarga de una carpeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Obtén los enlaces de descarga, ya sea de un único archivo o una carpeta entera
 * lxml
 * bs4
 * requests
+* aiohttp
 
 # Pasos para la obtención
 

--- a/mediafire2links.py
+++ b/mediafire2links.py
@@ -49,7 +49,7 @@ if (type == TYPE_FILE):
 
 elif (type == TYPE_FOLDER):
 	folder_key = id
-	content = requests.get("https://www.mediafire.com/api/1.4/folder/get_content.php?r=rgfa&content_type=files&filter=all&order_by=name&order_direction=asc&chunk=1&version=1.5&folder_key=%s&response_format=json" % (folder_key)).content
+	content = requests.get("https://www.mediafire.com/api/1.5/folder/get_content.php?content_type=files&filter=all&order_by=name&order_direction=asc&chunk=1&folder_key=%s&response_format=json" % (folder_key)).content
 	content_js = json.loads(content)
 	parsed = content_js["response"]
 	status = parsed["result"]

--- a/mediafire2links.py
+++ b/mediafire2links.py
@@ -4,6 +4,7 @@ import json
 import sys
 import requests
 import asyncio
+import aiohttp
 
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup as bs4


### PR DESCRIPTION
He mejorado la velocidad de obtención de los linsk de descarga de una carpeta de Mediafire con programación asyncrona y aiohttp.
Recomiendo usarlo en google colab, ya que si tienes muchos links de descarga, va a consumir mucho ancho de banda de internet.