### PR TITLE
Aumentar rapidez al obtener los linsk de descarga de una carpeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Obtén los enlaces de descarga, ya sea de un único archivo o una carpeta entera
 * lxml
 * bs4
 * requests
+* aiohttp
 
 # Pasos para la obtención
 

--- a/mediafire2links.py
+++ b/mediafire2links.py
@@ -49,7 +49,7 @@ if (type == TYPE_FILE):
 
 elif (type == TYPE_FOLDER):
 	folder_key = id
-	content = requests.get("https://www.mediafire.com/api/1.4/folder/get_content.php?r=rgfa&content_type=files&filter=all&order_by=name&order_direction=asc&chunk=1&version=1.5&folder_key=%s&response_format=json" % (folder_key)).content
+	content = requests.get("https://www.mediafire.com/api/1.5/folder/get_content.php?content_type=files&filter=all&order_by=name&order_direction=asc&chunk=1&folder_key=%s&response_format=json" % (folder_key)).content
 	content_js = json.loads(content)
 	parsed = content_js["response"]
 	status = parsed["result"]

--- a/mediafire2links.py
+++ b/mediafire2links.py
@@ -4,6 +4,7 @@ import json
 import sys
 import requests
 import asyncio
+import aiohttp
 
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup as bs4

--- a/mediafire2links.py
+++ b/mediafire2links.py
@@ -24,8 +24,7 @@ async def get_downloads(files):
 	async with aiohttp.ClientSession() as session:
 		links_download = []
 		
-		for x in files:
-			url = x["links"]["normal_download"]
+		for url in files:
 			links_download.append(asyncio.ensure_future(get_download(session, url)))
 			
 		links_mediafire = await asyncio.gather(*links_download)
@@ -48,7 +47,7 @@ if (type == TYPE_FILE):
 		print("Error, el nombre del sitio web al que intenta acceder no coincide con el correspondiente.")
 		sys.exit(1)
 
-	print(get_download(link))
+	asyncio.run(get_downloads([link]))
 
 elif (type == TYPE_FOLDER):
 	folder_key = id
@@ -62,6 +61,7 @@ elif (type == TYPE_FOLDER):
 		sys.exit(1)
 
 	files = parsed["folder_content"]["files"]
+	files = [x["links"]["normal_download"] for x in files]
 	asyncio.run(get_downloads(files))
 
 else:


### PR DESCRIPTION
He mejorado la velocidad de obtención de los linsk de descarga de una carpeta de Mediafire con programación asyncrona y aiohttp. 
Lo he probado con una carpeta con 37 archivos, lo cual me obtiene los links en 1 segundo (Google Colab).
Recomiendo usarlo en Google Colab, ya que si tienes muchos links de descarga, va a consumir mucho ancho de banda de internet.
El anterior pull request que hice tenía un problema, pero ya lo arreglé